### PR TITLE
Fix starting auction above the max start price temporarily freezing the plugin

### DIFF
--- a/src/main/java/org/garsooon/AuctionManager.java
+++ b/src/main/java/org/garsooon/AuctionManager.java
@@ -78,13 +78,6 @@ public class AuctionManager {
         Object durationObj = plugin.getCustomConfig().get("duration");
         if (durationObj instanceof Integer) duration = (Integer) durationObj;
 
-        auctionStartTime = System.currentTimeMillis();
-        auctionEndTime = auctionStartTime + (duration * 1000L);
-
-        parseIncrement(incrementArg);
-
-        currentSeller = seller;
-        currentItem = item;
         startPrice = roundDown2(price);
 
         Object maxStartPriceObj = plugin.getCustomConfig().get("max-start-price");
@@ -96,6 +89,14 @@ public class AuctionManager {
             seller.sendMessage(ChatColor.RED + "The maximum auction start price is $" + String.format("%.2f", maxStartPrice));
             return false;
         }
+
+        auctionStartTime = System.currentTimeMillis();
+        auctionEndTime = auctionStartTime + (duration * 1000L);
+
+        parseIncrement(incrementArg);
+
+        currentSeller = seller;
+        currentItem = item;
 
         highestBid = startPrice;
         highestBidder = null;


### PR DESCRIPTION
This was caused by `currentItem` getting filled before the max price check, which `isAuctionRunning()` uses to determine if the auction is running.